### PR TITLE
Remove un-needed CSS causing perf issues on Android 8

### DIFF
--- a/AnimatedProgressWheel.js
+++ b/AnimatedProgressWheel.js
@@ -129,7 +129,6 @@ const generateStyles = ({size, width, color, backgroundColor, containerColor}) =
             width: size,
             height: size,
             borderRadius: size / 2,
-            overflow: 'hidden',
         },
         background: {
             width: size,


### PR DESCRIPTION
Fixes #19 

Can you think of a strong reason this CSS was in there? Taking it out fixes the crippling performance on Android 8, and it visually still looks fine.
